### PR TITLE
Add PHP example for using the HTTP daemon in docs.

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -89,29 +89,17 @@ fetch("http://localhost:8080", requestOptions)
 
 * `PHP` (Symfony HttpClient)
 ```php
-use Symfony\Contracts\HttpClient\HttpClientInterface;
+$httpClient = HttpClient::create();
 
-class XrechnungValidator
-{
-  private $httpClient;
+$response = $this->httpClient->request('POST', 'http://localhost:8080', [
+  'headers' => [
+    'Content-Type' => 'application/xml',
+  ],
+  'body' => fopen('/path/to/some.xml', 'r'),
+]);
 
-  public function __construct(HttpClientInterface $httpClient)
-  {
-    $this->httpClient = $httpClient;
-  }
+echo $response->getContent();
 
-  public function validate()
-  {
-    $response = $this->httpClient->request('POST', 'http://localhost:8080', [
-      'headers' => [
-        'Content-Type' => 'application/xml',
-      ],
-      'body' => fopen('/path/to/some.xml', 'r'),
-    ]);
-
-    echo $response->getContent();
-  }
-}
 ```
 
 ## Status codes

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -86,6 +86,34 @@ fetch("http://localhost:8080", requestOptions)
   .then(result => console.log(result))
   .catch(error => console.log('error', error));
 ```
+
+* `PHP` (Symfony HttpClient)
+```php
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class XrechnungValidator
+{
+  private $httpClient;
+
+  public function __construct(HttpClientInterface $httpClient)
+  {
+    $this->httpClient = $httpClient;
+  }
+
+  public function validate()
+  {
+    $response = $this->httpClient->request('POST', 'http://localhost:8080', [
+      'headers' => [
+        'Content-Type' => 'application/xml',
+      ],
+      'body' => fopen('/path/to/some.xml', 'r'),
+    ]);
+
+    echo $response->getContent();
+  }
+}
+```
+
 ## Status codes
 | code | description |
 |-|-|

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -91,7 +91,7 @@ fetch("http://localhost:8080", requestOptions)
 ```php
 $httpClient = HttpClient::create();
 
-$response = $this->httpClient->request('POST', 'http://localhost:8080', [
+$response = $httpClient->request('POST', 'http://localhost:8080', [
   'headers' => [
     'Content-Type' => 'application/xml',
   ],


### PR DESCRIPTION
Wie angeboten, hier ein Vorschlag für ein kurzes Beispiel wie man mit PHP und dem HttpClient von Symfony auf den Validator zugreifen kann.