### PR TITLE
Bug fix for building scenario with schematron.

### DIFF
--- a/src/main/java/de/kosit/validationtool/impl/Scenario.java
+++ b/src/main/java/de/kosit/validationtool/impl/Scenario.java
@@ -16,7 +16,7 @@
 
 package de.kosit.validationtool.impl;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -80,7 +80,7 @@ public class Scenario {
     private Transformation reportTransformation;
 
     public List<Transformation> getSchematronValidations() {
-        return this.schematronValidations == null ? Collections.emptyList() : this.schematronValidations;
+        return this.schematronValidations == null ? new ArrayList<>() : this.schematronValidations;
     }
 
     public String getName() {

--- a/src/test/java/de/kosit/validationtool/config/ScenarioBuilderTest.java
+++ b/src/test/java/de/kosit/validationtool/config/ScenarioBuilderTest.java
@@ -141,6 +141,25 @@ public class ScenarioBuilderTest {
     }
 
     @Test
+    public void testConfigureWithSchematron() {
+        final ContentRepository repository = Simple.createContentRepository();
+        final XPathExecutable match = repository.createXPath("//*", null);
+        final XPathExecutable accept = repository.createXPath("//*", null);
+        final ScenarioBuilder builder = createScenario();
+        builder.getNamespaces().clear();
+
+        builder.match(match);
+        builder.acceptWith(accept);
+        final Result<Scenario, String> result = builder.build(repository);
+        assertThat(result.isValid()).isTrue();
+        final ScenarioType configuration = result.getObject().getConfiguration();
+        assertThat(configuration.getMatch()).isNotEmpty();
+        assertThat(configuration.getAcceptMatch()).isNotEmpty();
+        assertThat(configuration.getNamespace()).isEmpty();
+        assertThat(configuration.getValidateWithSchematron()).isNotEmpty();
+    }
+
+    @Test
     public void testBasicAttributes() {
         final ContentRepository repository = Simple.createContentRepository();
         final String random = RandomStringUtils.random(5);

--- a/src/test/java/de/kosit/validationtool/config/TestConfigurationFactory.java
+++ b/src/test/java/de/kosit/validationtool/config/TestConfigurationFactory.java
@@ -20,6 +20,7 @@ import static de.kosit.validationtool.config.ConfigurationBuilder.fallback;
 import static de.kosit.validationtool.config.ConfigurationBuilder.report;
 import static de.kosit.validationtool.config.ConfigurationBuilder.scenario;
 import static de.kosit.validationtool.config.ConfigurationBuilder.schema;
+import static de.kosit.validationtool.config.ConfigurationBuilder.schematron;
 
 import java.net.URI;
 import java.util.Date;
@@ -46,6 +47,7 @@ public class TestConfigurationFactory {
 
     public static ScenarioBuilder createScenario() {
         return scenario("simple").validate(schema("Sample Schema").schemaLocation(URI.create("simple.xsd")))
+                .validate(schematron("Sample Schematron").source(Simple.SCHEMATRON))
                 .with(report("Report für eRechnung").source("report.xsl")).acceptWith("count(//test:rejected) = 0")
                 .declareNamespace("cri", "http://www.xoev.de/de/validator/framework/1/createreportinput")
                 .declareNamespace("rpt", "http://validator.kosit.de/test-report")

--- a/src/test/java/de/kosit/validationtool/impl/Helper.java
+++ b/src/test/java/de/kosit/validationtool/impl/Helper.java
@@ -84,6 +84,8 @@ public class Helper {
 
         public static final URI SCHEMA = REPOSITORY_URI.resolve("simple.xsd");
 
+        public static final URI SCHEMATRON = REPOSITORY_URI.resolve("simple-schematron-error.xsl");
+
         public static final ContentRepository createContentRepository() {
             final ResolvingConfigurationStrategy strategy = ResolvingMode.STRICT_RELATIVE.getStrategy();
             return new ContentRepository(Helper.getTestProcessor(), strategy, Simple.REPOSITORY_URI);


### PR DESCRIPTION
The code of v1.5.0 contains a bug which prevents building a scenario with schematron via the API:

In function Scenario.getSchematronValidations the function returns an empty list when there are no schematronValidations. But the return value `Collections.emptyList()` is an **immutable** list which can not perform add method. This getter will be called in ScenarioBuilder.buildSchematron with an add operation to add the build result, which leads to an `UnsupportedOperationException`

This pull request did the bug fix and add the test case for this case.