### PR TITLE
set propertiesEncoding for maven-resource-plugin to ISO-88591-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,14 @@
                     <lineEnding>LF</lineEnding>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+                </configuration>
+            </plugin>
 
         </plugins>
     </build>


### PR DESCRIPTION
Set file encoding of property files to ISO-8859-1 